### PR TITLE
fix: address all 20 open review issues (#1–#21 excl. #12)

### DIFF
--- a/arxiv-submission/agentverse-paper.tex
+++ b/arxiv-submission/agentverse-paper.tex
@@ -249,8 +249,8 @@ Section~\ref{sec:conclusion} concludes.
 \subsection{Agent Infrastructure}
 \label{subsec:agent-infra}
 
-The theoretical foundations of agent infrastructure are established by
-\citet{chan2025infrastructure}, who identify three core functions that such
+\citet{chan2025infrastructure} establish the theoretical foundations of
+agent infrastructure, identifying three core functions that such
 infrastructure must serve: \emph{attribution} (establishing which agent, user,
 or organisation is responsible for a given action); \emph{interaction shaping}
 (protocols and systems that constrain or coordinate agent behaviour); and
@@ -270,8 +270,8 @@ term evidence supports this trajectory: \citet{kantor2026stateofagents} reports
 over 36,000 agents already registered on Agentverse as of March 2026, a figure
 that would have seemed implausible even two years prior.
 
-The economics of agent interaction are explored by \citet{hadfield2025agenteconomy},
-who model the agent economy as a labour market in which \textsc{ai} agents
+\citet{hadfield2025agenteconomy} explore the economics of agent interaction,
+modelling the agent economy as a labour market in which \textsc{ai} agents
 substitute for human workers across increasingly complex task domains.  Their
 analysis implies significant demand for infrastructure that supports agent
 \emph{hiring}, \emph{payment}, \emph{trust evaluation}, and \emph{performance
@@ -334,15 +334,20 @@ participation model that a truly interoperable agentic web requires.
 \textbf{Decentralised agent networks}---Agentverse (Fetch.ai / ASI Alliance),
 Virtuals Protocol, and ElizaOS---are built on open protocols and cryptographic
 identity, enabling permissionless agent registration and cross-platform
-interoperability.  They are closer in spirit to the internet itself (open,
-decentralised, protocol-governed) than to AWS (centralised, proprietary,
-subscription-governed).  However, they currently lack the managed service
-richness of hyperscaler platforms, which is precisely the gap this paper
-analyses.
+interoperability.\footnote{Virtuals Protocol and ElizaOS are included in this
+landscape overview for completeness.  Neither exposes a documented \textsc{rest}
+\textsc{api} surface comparable to Agentverse's, making a rigorous
+endpoint-level audit impractical.  This paper therefore focuses on Agentverse
+as the representative decentralised agent platform; a comparative study of
+all three platforms is left for future work.}  They are closer in spirit to
+the internet itself (open, decentralised, protocol-governed) than to AWS
+(centralised, proprietary, subscription-governed).  However, they currently
+lack the managed service richness of hyperscaler platforms, which is precisely
+the gap this paper analyses.
 
-Table~\ref{tab:platform-comparison} summarises the current capabilities of
-leading agent platforms along dimensions we consider essential for a production
-agent cloud.  We return to this comparison in Section~\ref{sec:discussion}.
+We compare the capabilities of these platforms along dimensions essential for
+a production agent cloud in Section~\ref{sec:discussion}
+(Table~\ref{tab:platform-comparison}).
 
 \subsection{Protocol Standards Landscape}
 \label{subsec:protocols}
@@ -492,7 +497,7 @@ autonomously \citep{fetchai2026payments}.
 
 \end{enumerate}
 
-The uAgents \textsc{sdk} (Python) provides the developer-facing abstraction:
+The uAgents \textsc{sdk} (Python) \citep{uagents2026sdk} provides the developer-facing abstraction:
 agents are defined as Python modules that respond to lifecycle events
 (\texttt{on\_event("startup")}), incoming messages
 (\texttt{@protocol.on\_message}), and \textsc{rest} requests
@@ -515,10 +520,10 @@ Our gap analysis is grounded in a systematic empirical audit of the Agentverse
 documented approximately \textbf{204 endpoints} across two \textsc{api}
 versions (\texttt{v1} and \texttt{v2}) at \url{https://agentverse.ai};
 the \textsc{api} surface is actively evolving, and endpoint availability may
-differ from this count at the time of reading.  We tested each endpoint
-category with authenticated requests using a production \textsc{api} key
-(scope: \texttt{av}), supplemented by analysis of the Fern-generated
-documentation, \textsc{sdk} source code, and community resources.
+differ from this count at the time of reading.  We tested each endpoint category with authenticated requests using a
+production \textsc{api} key (scope: \texttt{av}), supplemented by analysis of
+the Fern-generated documentation \citep{agentverse2026docs}, \textsc{sdk}
+source code, and community resources.
 
 Key findings from the audit:
 
@@ -635,7 +640,7 @@ state mechanism available to hosted agents.  It corresponds roughly to writing
 to a flat file: there is no schema, no query capability, no indexing, no size
 quota visibility, and no sharing between agents.
 
-Contemporary agent memory research \citep{mem0blog2026,zepgraphiti2025}
+Contemporary agent memory research \citep{mem0blog2026,zepgraphiti2025,yang2026graphsurvey}
 distinguishes four cognitively motivated memory types: \emph{episodic} (what
 happened, when, with whom), \emph{semantic} (facts, concepts, relationships),
 \emph{procedural} (how to do things, learned workflows), and \emph{working}
@@ -643,7 +648,8 @@ happened, when, with whom), \emph{semantic} (facts, concepts, relationships),
 hosted, authenticated services for each type.  The analogy to general-purpose
 cloud is precise: \texttt{ctx.storage} is to agent memory what writing to a
 local disk is to web application data---it works for a single instance in
-development but fails in production at scale.
+development but fails in production at scale.  Table~\ref{tab:gap-memory}
+summarises the seven gaps we identify in this category.
 
 \begin{table}[htbp]
 \centering
@@ -692,6 +698,7 @@ This stands in stark contrast to the rich observability ecosystems that have
 emerged for \textsc{llm} applications---LangSmith \citep{langsmith2026},
 AgentOps \citep{agentops2026}, and Langfuse \citep{langfuse2026}---all of
 which offer distributed tracing, token cost tracking, and behaviour analytics.
+Table~\ref{tab:gap-obs} enumerates the eight gaps in this category.
 
 \begin{table}[htbp]
 \centering
@@ -738,7 +745,8 @@ This is a significant concern given the OWASP Agentic AI Security Top 10
 hijacking, and cascading failures as the primary risk categories for autonomous
 agents.  The absence of a platform-level policy engine means that developers
 must implement all safety controls within agent code---which is both
-error-prone and inconsistent.
+error-prone and inconsistent.  Table~\ref{tab:gap-security} lists the eight
+security and governance gaps identified.
 
 \begin{table}[htbp]
 \centering
@@ -785,7 +793,8 @@ in an A2A task graph---it must use an adapter
 (\texttt{uagents-adapter[a2a-inbound/outbound]}) that translates between
 protocols.  As A2A becomes the de facto enterprise standard, this gap risks
 positioning Agentverse as an isolated ecosystem rather than a participant in
-the broader agentic web.
+the broader agentic web.  Table~\ref{tab:gap-networking} enumerates the
+eight networking and communication gaps.
 
 \begin{table}[htbp]
 \centering
@@ -826,7 +835,8 @@ projects, dependency declaration, or module imports beyond what the platform
 pre-installs.  There is no version control for deployed code, no staging
 environment, no \textsc{ci/cd} integration, and no local development
 emulator---meaning that all testing must be done against production
-infrastructure.
+infrastructure.  Table~\ref{tab:gap-dev} summarises the eight development
+and lifecycle gaps.
 
 \begin{table}[htbp]
 \centering
@@ -870,6 +880,7 @@ connecting \textsc{ai} agents to external tools.  A managed \textsc{mcp} server
 marketplace---offering agents access to web search, calendar, email, code
 execution, browser control, and database services---would dramatically expand
 the capability surface of every agent on the platform.
+Table~\ref{tab:gap-data} lists the seven data and integration service gaps.
 
 \begin{table}[htbp]
 \centering
@@ -911,7 +922,8 @@ design \citep{myerson2007mechanism}---to describe the set of basic operations
 that a functional agent economy requires: payment (exists), reputation
 (rudimentary), lending, insurance, and price discovery (all absent).  Each has
 a direct precedent in human financial systems and is tractable to implement on
-a programmable blockchain.
+a programmable blockchain.  Table~\ref{tab:gap-economy} enumerates the eight
+economic primitive gaps.
 
 \begin{table}[htbp]
 \centering
@@ -952,7 +964,8 @@ platform has not published uptime \textsc{sla}s, compliance certifications, or
 dedicated compute options.  These gaps are significant for enterprise adoption
 in regulated industries---financial services, healthcare, legal---where
 guaranteed uptime, data residency, and compliance certifications are
-prerequisites.
+prerequisites.  Table~\ref{tab:gap-enterprise} details the eight scale and
+enterprise gaps.
 
 \begin{table}[htbp]
 \centering
@@ -986,7 +999,7 @@ Regions & \medium \\
 \subsection{Summary}
 \label{subsec:gap-summary}
 
-Across the eight categories, we identify \textbf{52 distinct capability gaps}.
+Across the eight categories, we identify \textbf{62 distinct capability gaps}.
 The concentration of High-severity gaps in Categories A (Memory), C (Security),
 D (Networking), E (Development), F (Data Services), and H (Enterprise) reflects
 the platform's current positioning as a capable prototype rather than a
@@ -1011,7 +1024,8 @@ agent cloud must provide, from cryptographic identity at the substrate to
 economic exchange at the application layer.  Each layer addresses one or more
 gap categories from Section~\ref{sec:gaps}.  The layers are ordered from
 infrastructure (Layer~0) to application (Layer~6), following the convention
-of the \textsc{osi} model.
+of the \textsc{osi} model.  The complete stack is depicted in
+Figure~\ref{fig:stack}.
 
 \begin{figure}[htbp]
 \centering
@@ -1444,7 +1458,7 @@ compliance tiers for regulated industries.
 \subsection{Limitations}
 \label{subsec:limitations}
 
-Our analysis has three principal limitations.  First, it is grounded in a
+Our analysis has four principal limitations.  First, it is grounded in a
 single platform at a specific time; some gaps may not generalise to platforms
 with different architectural choices.  Second, the 2030 projections are
 conditional on current trajectories and could be materially altered by
@@ -1452,6 +1466,13 @@ technical breakthroughs or regulatory intervention.  Third, the economic
 primitives in Sections~\ref{subsec:layer6} and~\ref{subsec:path-economy} are
 proposed without formal analysis of their incentive properties; rigorous
 mechanism design treatment of each would require dedicated theoretical work.
+Fourth, the empirical audit is categorical rather than quantitative: we
+characterise endpoints as operational, partially deployed, or absent, but do
+not report \textsc{api} response-time distributions, storage throughput
+benchmarks, or Almanac search quality metrics.  Future work should conduct
+controlled performance experiments to complement this taxonomy with
+quantitative empirical data, which would materially strengthen the
+contribution for submission to a peer-reviewed venue.
 
 % =============================================================================
 \section{Conclusion}
@@ -1460,7 +1481,7 @@ mechanism design treatment of each would require dedicated theoretical work.
 
 We have presented a systematic analysis of the Agentverse platform as a case
 study in agent-native cloud infrastructure.  Our empirical audit of 204 \textsc{api} endpoints (as documented in Q1~2026)
-reveals 52 capability gaps across eight
+reveals 62 capability gaps across eight
 categories---from agent memory and observability to security, communication,
 data services, economic primitives, and enterprise-grade scaling.  These gaps
 are not failures of vision but the natural condition of pioneering

--- a/arxiv-submission/agentverse-paper.tex
+++ b/arxiv-submission/agentverse-paper.tex
@@ -85,7 +85,7 @@
 \newcommand{\low}{\textcolor{green!50!black}{\textbf{Low}}}
 
 % -- JMLR heading macros ------------------------------------------------------
-\jmlrheading{1}{2026}{1-\pageref{LastPage}}{4/26}{}{}{Dey and Viradecha}
+\jmlrheading{1}{2026}{1-\pageref{LastPage}}{}{}{}{Dey and Viradecha}
 \ShortHeadings{Infrastructure for the Agentic Web}{Dey and Viradecha}
 \firstpageno{1}
 
@@ -125,9 +125,9 @@ represents one of the most mature and complete production deployments of
 agent-native infrastructure available today.
 
 We make three principal contributions.  First, we conduct a rigorous empirical
-audit of the Agentverse platform, cataloguing its 204 documented \textsc{api}
-endpoints and characterising what is operational, what is partially deployed,
-and what remains absent.  From this audit we derive a structured \textbf{Gap
+audit of the Agentverse platform, cataloguing 204 \textsc{api} endpoints
+as documented at the time of writing (Q1~2026) and characterising what is
+operational, what is partially deployed, and what remains absent.  From this audit we derive a structured \textbf{Gap
 Taxonomy}---eight categories encompassing approximately fifty missing
 infrastructure capabilities, ranging from agent memory and observability to
 security, economic primitives, and enterprise-grade scaling.  Second, we
@@ -170,16 +170,17 @@ coordination into the web's fabric.  Each transition was enabled not primarily
 by new \emph{applications} but by new \emph{infrastructure}: foundational
 platforms that made a previously impractical class of systems tractable.
 
-We are now at the beginning of a fourth such transition.  Web4, variously
-termed the \emph{agentic web} or the \emph{symbiotic web}
-\citep{eph4ai2026}, is characterised by the presence of autonomous \textsc{ai}
-agents as primary actors on the internet---software entities that perceive
-their environment, reason about goals, execute multi-step plans, communicate
-with other agents, and transact economically, all without requiring human
-intervention at each step.  The transition from Web3 to Web4 parallels in
-important respects the transition from Web1 to Web2: the applications (agents)
-already exist in prototype form, but the infrastructure required to operate
-them reliably, safely, and at scale remains nascent.
+We are now at the beginning of a fourth such transition.  What some authors
+term Web4 or the \emph{agentic web} \citep{eph4ai2026}---also variously
+called the \emph{symbiotic web}---is characterised by the presence of
+autonomous \textsc{ai} agents as primary actors on the internet: software
+entities that perceive their environment, reason about goals, execute
+multi-step plans, communicate with other agents, and transact economically,
+all without requiring human intervention at each step.  The transition from
+Web3 to this agentic era parallels in important respects the transition from
+Web1 to Web2: the applications (agents) already exist in prototype form, but
+the infrastructure required to operate them reliably, safely, and at scale
+remains nascent.
 
 \citet{chan2025infrastructure} articulate the concept of \emph{agent
 infrastructure}---``technical systems and shared protocols external to agents
@@ -213,15 +214,20 @@ forthcoming ASI Chain), giving it architectural properties---open identity,
 permissionless participation, cryptographic trust---that hyperscaler agent
 offerings \citep{aws2025bedrock,microsoft2025entra,google2026next} do not
 share.  And crucially, it is a production system with real registered agents
-(over 36,000 in the Almanac as of Q1 2026 \citep{kantor2026stateofagents}),
+(over 36,000 in the Almanac as of Q1 2026
+\citep{kantor2026stateofagents}\footnote{The Agentverse search \textsc{api}
+caps results at 10,000 entries; the 36,000-plus figure is sourced from
+\citeauthor{kantor2026stateofagents}'s cross-platform registry aggregation,
+which queries the Almanac directly rather than through the search interface.}),
 real developer communities, and real \textsc{api} endpoints that can be
 empirically tested.
 
-Our investigation proceeds from a hands-on audit of all 204 documented
-Agentverse \textsc{api} endpoints, supplemented by analysis of the uAgents
-\textsc{sdk}, the ASI:One \textsc{llm} \textsc{api}, and the platform's
-\textsc{mcp} integration layer.  From this empirical foundation we derive our
-gap taxonomy, architecture, and evolution paths.
+Our investigation proceeds from a hands-on audit of 204 documented
+Agentverse \textsc{api} endpoints as catalogued at the time of writing
+(Q1~2026), supplemented by analysis of the uAgents \textsc{sdk}, the
+ASI:One \textsc{llm} \textsc{api}, and the platform's \textsc{mcp}
+integration layer.  From this empirical foundation we derive our gap
+taxonomy, architecture, and evolution paths.
 
 The remainder of the paper is structured as follows.
 Section~\ref{sec:background} surveys related work on agent infrastructure,
@@ -286,10 +292,12 @@ that create lasting competitive advantage are those that solve the hard
 operational problems developers face \emph{after} they have compute---
 authentication, persistence, observability, scaling, and compliance.
 
-We observe that Agentverse in 2026 is approximately at the AWS 2006 stage: it
-has primitive compute (hosted agents), a registry (Almanac), and messaging
-(mailbox).  The gap between this and a mature agent cloud platform is analogous
-to the gap between AWS in 2006 and AWS today.
+We observe that Agentverse in 2026 occupies a position analogous to AWS in
+2006: it has established the essential primitives---compute (hosted agents),
+a registry (Almanac), and messaging (mailbox)---on which the full agent cloud
+can be built.  Just as AWS expanded from three core services in 2006 to over
+200 today, the trajectory from Agentverse's current foundation to a mature
+agent cloud platform is both ambitious and well-defined.
 
 The cloud computing literature establishes a layered abstraction model:
 \textsc{iaas} $\to$ \textsc{paas} $\to$ \textsc{saas} $\to$ \textsc{faas}.
@@ -468,13 +476,14 @@ messages for agents that are temporarily offline, enabling reliable
 agent-to-agent communication without requiring both parties to be simultaneously
 active.
 
-\item \textbf{ASI:One}: A multi-model \textsc{llm} \textsc{api} offering seven
-seven models via an OpenAI-compatible endpoint (\texttt{api.asi1.ai}):
-\texttt{asi1}, \texttt{asi1-fast}, \texttt{asi1-extended},
-\texttt{asi1-graph}, \texttt{asi1-agentic}, \texttt{asi1-fast-agentic},
-and \texttt{asi1-extended-agentic}.  The \textsc{api} additionally supports real-time web
-search, structured output with \textsc{json} schema, image generation, and
-streaming.
+\item \textbf{ASI:One}: A unified \textsc{llm} \textsc{api} available via an
+OpenAI-compatible endpoint (\texttt{api.asi1.ai/v1}).  The primary model,
+\texttt{asi1}, is a unified model that automatically adapts its capabilities
+based on the request---activating agentic reasoning, extended analysis, fast
+inference, tool calling, or knowledge-graph traversal as needed.  A
+lightweight variant, \texttt{asi1-mini}, is available for resource-constrained
+applications.  The \textsc{api} additionally supports real-time web search,
+structured output with \textsc{json} schema, image generation, and streaming.
 
 \item \textbf{Payment Protocol}: A built-in buyer-seller protocol supporting
 Stripe (fiat), Skyfire \textsc{usdc}, and \textsc{fet}/\textsc{asi} on-chain
@@ -502,12 +511,14 @@ Desktop and FetchCoder.
 \label{subsec:audit}
 
 Our gap analysis is grounded in a systematic empirical audit of the Agentverse
-\textsc{api} surface.  The platform exposes approximately \textbf{204
-documented endpoints} across two \textsc{api} versions (\texttt{v1} and
-\texttt{v2}) at \url{https://agentverse.ai}.  We tested each endpoint category
-with authenticated requests using a production \textsc{api} key (scope:
-\texttt{av}), supplemented by analysis of the Fern-generated documentation,
-\textsc{sdk} source code, and community resources.
+\textsc{api} surface.  At the time of our audit (Q1~2026), the platform
+documented approximately \textbf{204 endpoints} across two \textsc{api}
+versions (\texttt{v1} and \texttt{v2}) at \url{https://agentverse.ai};
+the \textsc{api} surface is actively evolving, and endpoint availability may
+differ from this count at the time of reading.  We tested each endpoint
+category with authenticated requests using a production \textsc{api} key
+(scope: \texttt{av}), supplemented by analysis of the Fern-generated
+documentation, \textsc{sdk} source code, and community resources.
 
 Key findings from the audit:
 
@@ -520,8 +531,11 @@ token.
 beyond the basic bearer token (notably, mailbox endpoints require agent-level
 attestation via challenge-response).
 
-\item \textbf{V2 Almanac and most V2 Hosting endpoints return 404}---they are
-documented but not yet deployed to production.
+\item \textbf{V2 Almanac resolve is operational} (returning full agent records);
+other V2 Almanac endpoints return 404.  Several V2 Hosting list endpoints
+(\texttt{/agents}, \texttt{/secrets}, \texttt{/storage}) are deployed but
+require authentication (401); most V2 Hosting per-agent endpoints return
+404---documented but not yet available in production.
 
 \item \textbf{The practical working \textsc{api} mixes V2 for agent
 \textsc{crud}} (create, read, update, delete) \textbf{and V1 for hosting,
@@ -549,7 +563,11 @@ Section~\ref{sec:gaps}.  The discrepancy between documented and deployed
 endpoints is itself instructive: it suggests that the platform team has
 articulated a broader vision than the current production system realises,
 consistent with our characterisation of Agentverse as an early-stage agent
-cloud undergoing rapid expansion.
+cloud undergoing rapid expansion.  We note that the \textsc{api} surface is
+actively evolving; some endpoints documented at the time of our audit have
+since been modified, consolidated, or deprecated, and new ones may have
+been added.  All quantitative endpoint claims in this paper should be read
+with this dynamism in mind.
 
 \subsection{What Currently Works Well}
 \label{subsec:strengths}
@@ -574,10 +592,11 @@ the Almanac without approval, enabling a genuinely open ecosystem.  The over
 36,000 agents discoverable in the Almanac as of Q1 2026 reflects the traction
 this openness creates.
 
-\textbf{Multi-model \textsc{llm} access.} ASI:One provides access to seven
-specialised models via a single \textsc{api}, including an agentic model family
-designed for tool use and multi-step reasoning, and a graph model for
-structured knowledge tasks.
+\textbf{Unified \textsc{llm} access.} ASI:One provides a single \textsc{api}
+(\texttt{asi1}) that automatically adapts its capabilities to the request,
+encompassing agentic reasoning, tool use, extended analysis, and structured
+knowledge tasks.  A lightweight \texttt{asi1-mini} variant complements it for
+resource-constrained applications.
 
 \textbf{Native payment protocol.} The integration of payment as a first-class
 protocol (rather than a bolt-on billing system) reflects a principled design
@@ -589,9 +608,9 @@ Agentverse is built on an open blockchain, meaning that the Almanac, agent
 identities, and on-chain transactions are not owned by any single corporation
 and cannot be unilaterally revoked.
 
-These strengths position Agentverse as the correct foundation on which to build
-the agent cloud of 2030.  The gap analysis that follows should be read not as
-a critique but as a roadmap.
+These strengths position Agentverse as the strongest decentralised foundation
+currently available for building the agent cloud of 2030.  The gap analysis
+that follows should be read not as a critique but as a roadmap.
 
 % =============================================================================
 \section{Gap Analysis: What the Agent Cloud Is Missing}
@@ -985,10 +1004,14 @@ designed to close the gaps while preserving these advantages.
 
 Drawing on the gap analysis of Section~\ref{sec:gaps} and the cloud computing
 reference model of Section~\ref{subsec:cloud-reference}, we propose a
-seven-layer reference architecture for a fully realised agent cloud platform.
-Each layer addresses one or more gap categories from Section~\ref{sec:gaps}.
-The layers are ordered from infrastructure (Layer~0) to application (Layer~6),
-following the convention of the \textsc{osi} model.
+seven-layer reference architecture for a fully realised \textsc{aaas} (Agents
+as a Service) cloud platform.  This stack is the \textsc{aaas} equivalent of
+the \textsc{osi} model: a principled decomposition of every capability an
+agent cloud must provide, from cryptographic identity at the substrate to
+economic exchange at the application layer.  Each layer addresses one or more
+gap categories from Section~\ref{sec:gaps}.  The layers are ordered from
+infrastructure (Layer~0) to application (Layer~6), following the convention
+of the \textsc{osi} model.
 
 \begin{figure}[htbp]
 \centering
@@ -1405,7 +1428,8 @@ agent markets with heterogeneous participants is an open problem.
 \subsection{Regulatory Considerations}
 \label{subsec:regulatory}
 
-The EU AI Act (high-risk provisions in force from August 2, 2026) classifies
+The EU AI Act (Regulation (EU)~2024/1689; high-risk provisions in force from
+August~2, 2026) classifies
 \textsc{ai} systems by risk level.  Autonomous agents taking consequential
 actions---financial transactions, medical decisions, legal submissions---are
 likely to be classified as high-risk, triggering requirements for human
@@ -1435,8 +1459,8 @@ mechanism design treatment of each would require dedicated theoretical work.
 % =============================================================================
 
 We have presented a systematic analysis of the Agentverse platform as a case
-study in agent-native cloud infrastructure.  Our empirical audit of 204
-\textsc{api} endpoints reveals 52 capability gaps across eight
+study in agent-native cloud infrastructure.  Our empirical audit of 204 \textsc{api} endpoints (as documented in Q1~2026)
+reveals 52 capability gaps across eight
 categories---from agent memory and observability to security, communication,
 data services, economic primitives, and enterprise-grade scaling.  These gaps
 are not failures of vision but the natural condition of pioneering
@@ -1466,7 +1490,10 @@ communicate across platforms, verify each other's identity, and transact
 economically---will shape outcomes in commerce, science, and governance far
 beyond the scope of any individual agent application.  Agentverse, uniquely
 among current platforms, is architecturally positioned to provide that
-infrastructure in an open, decentralised, and composable form.  The distance
+infrastructure in an open, decentralised, and composable form.  The seven-layer
+stack we propose constitutes the full \textsc{aaas} (Agents as a Service)
+model: the principled service abstraction for the agentic era, as foundational
+to the agent cloud as \textsc{iaas} was to the compute cloud.  The distance
 between where it is today and where it needs to be by 2030 is large but
 well-defined.  This paper is a map of that distance.
 

--- a/paper/agentverse-paper.tex
+++ b/paper/agentverse-paper.tex
@@ -249,8 +249,8 @@ Section~\ref{sec:conclusion} concludes.
 \subsection{Agent Infrastructure}
 \label{subsec:agent-infra}
 
-The theoretical foundations of agent infrastructure are established by
-\citet{chan2025infrastructure}, who identify three core functions that such
+\citet{chan2025infrastructure} establish the theoretical foundations of
+agent infrastructure, identifying three core functions that such
 infrastructure must serve: \emph{attribution} (establishing which agent, user,
 or organisation is responsible for a given action); \emph{interaction shaping}
 (protocols and systems that constrain or coordinate agent behaviour); and
@@ -270,8 +270,8 @@ term evidence supports this trajectory: \citet{kantor2026stateofagents} reports
 over 36,000 agents already registered on Agentverse as of March 2026, a figure
 that would have seemed implausible even two years prior.
 
-The economics of agent interaction are explored by \citet{hadfield2025agenteconomy},
-who model the agent economy as a labour market in which \textsc{ai} agents
+\citet{hadfield2025agenteconomy} explore the economics of agent interaction,
+modelling the agent economy as a labour market in which \textsc{ai} agents
 substitute for human workers across increasingly complex task domains.  Their
 analysis implies significant demand for infrastructure that supports agent
 \emph{hiring}, \emph{payment}, \emph{trust evaluation}, and \emph{performance
@@ -334,15 +334,20 @@ participation model that a truly interoperable agentic web requires.
 \textbf{Decentralised agent networks}---Agentverse (Fetch.ai / ASI Alliance),
 Virtuals Protocol, and ElizaOS---are built on open protocols and cryptographic
 identity, enabling permissionless agent registration and cross-platform
-interoperability.  They are closer in spirit to the internet itself (open,
-decentralised, protocol-governed) than to AWS (centralised, proprietary,
-subscription-governed).  However, they currently lack the managed service
-richness of hyperscaler platforms, which is precisely the gap this paper
-analyses.
+interoperability.\footnote{Virtuals Protocol and ElizaOS are included in this
+landscape overview for completeness.  Neither exposes a documented \textsc{rest}
+\textsc{api} surface comparable to Agentverse's, making a rigorous
+endpoint-level audit impractical.  This paper therefore focuses on Agentverse
+as the representative decentralised agent platform; a comparative study of
+all three platforms is left for future work.}  They are closer in spirit to
+the internet itself (open, decentralised, protocol-governed) than to AWS
+(centralised, proprietary, subscription-governed).  However, they currently
+lack the managed service richness of hyperscaler platforms, which is precisely
+the gap this paper analyses.
 
-Table~\ref{tab:platform-comparison} summarises the current capabilities of
-leading agent platforms along dimensions we consider essential for a production
-agent cloud.  We return to this comparison in Section~\ref{sec:discussion}.
+We compare the capabilities of these platforms along dimensions essential for
+a production agent cloud in Section~\ref{sec:discussion}
+(Table~\ref{tab:platform-comparison}).
 
 \subsection{Protocol Standards Landscape}
 \label{subsec:protocols}
@@ -492,7 +497,7 @@ autonomously \citep{fetchai2026payments}.
 
 \end{enumerate}
 
-The uAgents \textsc{sdk} (Python) provides the developer-facing abstraction:
+The uAgents \textsc{sdk} (Python) \citep{uagents2026sdk} provides the developer-facing abstraction:
 agents are defined as Python modules that respond to lifecycle events
 (\texttt{on\_event("startup")}), incoming messages
 (\texttt{@protocol.on\_message}), and \textsc{rest} requests
@@ -515,10 +520,10 @@ Our gap analysis is grounded in a systematic empirical audit of the Agentverse
 documented approximately \textbf{204 endpoints} across two \textsc{api}
 versions (\texttt{v1} and \texttt{v2}) at \url{https://agentverse.ai};
 the \textsc{api} surface is actively evolving, and endpoint availability may
-differ from this count at the time of reading.  We tested each endpoint
-category with authenticated requests using a production \textsc{api} key
-(scope: \texttt{av}), supplemented by analysis of the Fern-generated
-documentation, \textsc{sdk} source code, and community resources.
+differ from this count at the time of reading.  We tested each endpoint category with authenticated requests using a
+production \textsc{api} key (scope: \texttt{av}), supplemented by analysis of
+the Fern-generated documentation \citep{agentverse2026docs}, \textsc{sdk}
+source code, and community resources.
 
 Key findings from the audit:
 
@@ -635,7 +640,7 @@ state mechanism available to hosted agents.  It corresponds roughly to writing
 to a flat file: there is no schema, no query capability, no indexing, no size
 quota visibility, and no sharing between agents.
 
-Contemporary agent memory research \citep{mem0blog2026,zepgraphiti2025}
+Contemporary agent memory research \citep{mem0blog2026,zepgraphiti2025,yang2026graphsurvey}
 distinguishes four cognitively motivated memory types: \emph{episodic} (what
 happened, when, with whom), \emph{semantic} (facts, concepts, relationships),
 \emph{procedural} (how to do things, learned workflows), and \emph{working}
@@ -643,7 +648,8 @@ happened, when, with whom), \emph{semantic} (facts, concepts, relationships),
 hosted, authenticated services for each type.  The analogy to general-purpose
 cloud is precise: \texttt{ctx.storage} is to agent memory what writing to a
 local disk is to web application data---it works for a single instance in
-development but fails in production at scale.
+development but fails in production at scale.  Table~\ref{tab:gap-memory}
+summarises the seven gaps we identify in this category.
 
 \begin{table}[htbp]
 \centering
@@ -692,6 +698,7 @@ This stands in stark contrast to the rich observability ecosystems that have
 emerged for \textsc{llm} applications---LangSmith \citep{langsmith2026},
 AgentOps \citep{agentops2026}, and Langfuse \citep{langfuse2026}---all of
 which offer distributed tracing, token cost tracking, and behaviour analytics.
+Table~\ref{tab:gap-obs} enumerates the eight gaps in this category.
 
 \begin{table}[htbp]
 \centering
@@ -738,7 +745,8 @@ This is a significant concern given the OWASP Agentic AI Security Top 10
 hijacking, and cascading failures as the primary risk categories for autonomous
 agents.  The absence of a platform-level policy engine means that developers
 must implement all safety controls within agent code---which is both
-error-prone and inconsistent.
+error-prone and inconsistent.  Table~\ref{tab:gap-security} lists the eight
+security and governance gaps identified.
 
 \begin{table}[htbp]
 \centering
@@ -785,7 +793,8 @@ in an A2A task graph---it must use an adapter
 (\texttt{uagents-adapter[a2a-inbound/outbound]}) that translates between
 protocols.  As A2A becomes the de facto enterprise standard, this gap risks
 positioning Agentverse as an isolated ecosystem rather than a participant in
-the broader agentic web.
+the broader agentic web.  Table~\ref{tab:gap-networking} enumerates the
+eight networking and communication gaps.
 
 \begin{table}[htbp]
 \centering
@@ -826,7 +835,8 @@ projects, dependency declaration, or module imports beyond what the platform
 pre-installs.  There is no version control for deployed code, no staging
 environment, no \textsc{ci/cd} integration, and no local development
 emulator---meaning that all testing must be done against production
-infrastructure.
+infrastructure.  Table~\ref{tab:gap-dev} summarises the eight development
+and lifecycle gaps.
 
 \begin{table}[htbp]
 \centering
@@ -870,6 +880,7 @@ connecting \textsc{ai} agents to external tools.  A managed \textsc{mcp} server
 marketplace---offering agents access to web search, calendar, email, code
 execution, browser control, and database services---would dramatically expand
 the capability surface of every agent on the platform.
+Table~\ref{tab:gap-data} lists the seven data and integration service gaps.
 
 \begin{table}[htbp]
 \centering
@@ -911,7 +922,8 @@ design \citep{myerson2007mechanism}---to describe the set of basic operations
 that a functional agent economy requires: payment (exists), reputation
 (rudimentary), lending, insurance, and price discovery (all absent).  Each has
 a direct precedent in human financial systems and is tractable to implement on
-a programmable blockchain.
+a programmable blockchain.  Table~\ref{tab:gap-economy} enumerates the eight
+economic primitive gaps.
 
 \begin{table}[htbp]
 \centering
@@ -952,7 +964,8 @@ platform has not published uptime \textsc{sla}s, compliance certifications, or
 dedicated compute options.  These gaps are significant for enterprise adoption
 in regulated industries---financial services, healthcare, legal---where
 guaranteed uptime, data residency, and compliance certifications are
-prerequisites.
+prerequisites.  Table~\ref{tab:gap-enterprise} details the eight scale and
+enterprise gaps.
 
 \begin{table}[htbp]
 \centering
@@ -986,7 +999,7 @@ Regions & \medium \\
 \subsection{Summary}
 \label{subsec:gap-summary}
 
-Across the eight categories, we identify \textbf{52 distinct capability gaps}.
+Across the eight categories, we identify \textbf{62 distinct capability gaps}.
 The concentration of High-severity gaps in Categories A (Memory), C (Security),
 D (Networking), E (Development), F (Data Services), and H (Enterprise) reflects
 the platform's current positioning as a capable prototype rather than a
@@ -1011,7 +1024,8 @@ agent cloud must provide, from cryptographic identity at the substrate to
 economic exchange at the application layer.  Each layer addresses one or more
 gap categories from Section~\ref{sec:gaps}.  The layers are ordered from
 infrastructure (Layer~0) to application (Layer~6), following the convention
-of the \textsc{osi} model.
+of the \textsc{osi} model.  The complete stack is depicted in
+Figure~\ref{fig:stack}.
 
 \begin{figure}[htbp]
 \centering
@@ -1444,7 +1458,7 @@ compliance tiers for regulated industries.
 \subsection{Limitations}
 \label{subsec:limitations}
 
-Our analysis has three principal limitations.  First, it is grounded in a
+Our analysis has four principal limitations.  First, it is grounded in a
 single platform at a specific time; some gaps may not generalise to platforms
 with different architectural choices.  Second, the 2030 projections are
 conditional on current trajectories and could be materially altered by
@@ -1452,6 +1466,13 @@ technical breakthroughs or regulatory intervention.  Third, the economic
 primitives in Sections~\ref{subsec:layer6} and~\ref{subsec:path-economy} are
 proposed without formal analysis of their incentive properties; rigorous
 mechanism design treatment of each would require dedicated theoretical work.
+Fourth, the empirical audit is categorical rather than quantitative: we
+characterise endpoints as operational, partially deployed, or absent, but do
+not report \textsc{api} response-time distributions, storage throughput
+benchmarks, or Almanac search quality metrics.  Future work should conduct
+controlled performance experiments to complement this taxonomy with
+quantitative empirical data, which would materially strengthen the
+contribution for submission to a peer-reviewed venue.
 
 % =============================================================================
 \section{Conclusion}
@@ -1460,7 +1481,7 @@ mechanism design treatment of each would require dedicated theoretical work.
 
 We have presented a systematic analysis of the Agentverse platform as a case
 study in agent-native cloud infrastructure.  Our empirical audit of 204 \textsc{api} endpoints (as documented in Q1~2026)
-reveals 52 capability gaps across eight
+reveals 62 capability gaps across eight
 categories---from agent memory and observability to security, communication,
 data services, economic primitives, and enterprise-grade scaling.  These gaps
 are not failures of vision but the natural condition of pioneering

--- a/paper/agentverse-paper.tex
+++ b/paper/agentverse-paper.tex
@@ -85,7 +85,7 @@
 \newcommand{\low}{\textcolor{green!50!black}{\textbf{Low}}}
 
 % -- JMLR heading macros ------------------------------------------------------
-\jmlrheading{1}{2026}{1-\pageref{LastPage}}{4/26}{}{}{Dey and Viradecha}
+\jmlrheading{1}{2026}{1-\pageref{LastPage}}{}{}{}{Dey and Viradecha}
 \ShortHeadings{Infrastructure for the Agentic Web}{Dey and Viradecha}
 \firstpageno{1}
 
@@ -125,9 +125,9 @@ represents one of the most mature and complete production deployments of
 agent-native infrastructure available today.
 
 We make three principal contributions.  First, we conduct a rigorous empirical
-audit of the Agentverse platform, cataloguing its 204 documented \textsc{api}
-endpoints and characterising what is operational, what is partially deployed,
-and what remains absent.  From this audit we derive a structured \textbf{Gap
+audit of the Agentverse platform, cataloguing 204 \textsc{api} endpoints
+as documented at the time of writing (Q1~2026) and characterising what is
+operational, what is partially deployed, and what remains absent.  From this audit we derive a structured \textbf{Gap
 Taxonomy}---eight categories encompassing approximately fifty missing
 infrastructure capabilities, ranging from agent memory and observability to
 security, economic primitives, and enterprise-grade scaling.  Second, we
@@ -170,16 +170,17 @@ coordination into the web's fabric.  Each transition was enabled not primarily
 by new \emph{applications} but by new \emph{infrastructure}: foundational
 platforms that made a previously impractical class of systems tractable.
 
-We are now at the beginning of a fourth such transition.  Web4, variously
-termed the \emph{agentic web} or the \emph{symbiotic web}
-\citep{eph4ai2026}, is characterised by the presence of autonomous \textsc{ai}
-agents as primary actors on the internet---software entities that perceive
-their environment, reason about goals, execute multi-step plans, communicate
-with other agents, and transact economically, all without requiring human
-intervention at each step.  The transition from Web3 to Web4 parallels in
-important respects the transition from Web1 to Web2: the applications (agents)
-already exist in prototype form, but the infrastructure required to operate
-them reliably, safely, and at scale remains nascent.
+We are now at the beginning of a fourth such transition.  What some authors
+term Web4 or the \emph{agentic web} \citep{eph4ai2026}---also variously
+called the \emph{symbiotic web}---is characterised by the presence of
+autonomous \textsc{ai} agents as primary actors on the internet: software
+entities that perceive their environment, reason about goals, execute
+multi-step plans, communicate with other agents, and transact economically,
+all without requiring human intervention at each step.  The transition from
+Web3 to this agentic era parallels in important respects the transition from
+Web1 to Web2: the applications (agents) already exist in prototype form, but
+the infrastructure required to operate them reliably, safely, and at scale
+remains nascent.
 
 \citet{chan2025infrastructure} articulate the concept of \emph{agent
 infrastructure}---``technical systems and shared protocols external to agents
@@ -213,15 +214,20 @@ forthcoming ASI Chain), giving it architectural properties---open identity,
 permissionless participation, cryptographic trust---that hyperscaler agent
 offerings \citep{aws2025bedrock,microsoft2025entra,google2026next} do not
 share.  And crucially, it is a production system with real registered agents
-(over 36,000 in the Almanac as of Q1 2026 \citep{kantor2026stateofagents}),
+(over 36,000 in the Almanac as of Q1 2026
+\citep{kantor2026stateofagents}\footnote{The Agentverse search \textsc{api}
+caps results at 10,000 entries; the 36,000-plus figure is sourced from
+\citeauthor{kantor2026stateofagents}'s cross-platform registry aggregation,
+which queries the Almanac directly rather than through the search interface.}),
 real developer communities, and real \textsc{api} endpoints that can be
 empirically tested.
 
-Our investigation proceeds from a hands-on audit of all 204 documented
-Agentverse \textsc{api} endpoints, supplemented by analysis of the uAgents
-\textsc{sdk}, the ASI:One \textsc{llm} \textsc{api}, and the platform's
-\textsc{mcp} integration layer.  From this empirical foundation we derive our
-gap taxonomy, architecture, and evolution paths.
+Our investigation proceeds from a hands-on audit of 204 documented
+Agentverse \textsc{api} endpoints as catalogued at the time of writing
+(Q1~2026), supplemented by analysis of the uAgents \textsc{sdk}, the
+ASI:One \textsc{llm} \textsc{api}, and the platform's \textsc{mcp}
+integration layer.  From this empirical foundation we derive our gap
+taxonomy, architecture, and evolution paths.
 
 The remainder of the paper is structured as follows.
 Section~\ref{sec:background} surveys related work on agent infrastructure,
@@ -286,10 +292,12 @@ that create lasting competitive advantage are those that solve the hard
 operational problems developers face \emph{after} they have compute---
 authentication, persistence, observability, scaling, and compliance.
 
-We observe that Agentverse in 2026 is approximately at the AWS 2006 stage: it
-has primitive compute (hosted agents), a registry (Almanac), and messaging
-(mailbox).  The gap between this and a mature agent cloud platform is analogous
-to the gap between AWS in 2006 and AWS today.
+We observe that Agentverse in 2026 occupies a position analogous to AWS in
+2006: it has established the essential primitives---compute (hosted agents),
+a registry (Almanac), and messaging (mailbox)---on which the full agent cloud
+can be built.  Just as AWS expanded from three core services in 2006 to over
+200 today, the trajectory from Agentverse's current foundation to a mature
+agent cloud platform is both ambitious and well-defined.
 
 The cloud computing literature establishes a layered abstraction model:
 \textsc{iaas} $\to$ \textsc{paas} $\to$ \textsc{saas} $\to$ \textsc{faas}.
@@ -468,13 +476,14 @@ messages for agents that are temporarily offline, enabling reliable
 agent-to-agent communication without requiring both parties to be simultaneously
 active.
 
-\item \textbf{ASI:One}: A multi-model \textsc{llm} \textsc{api} offering seven
-seven models via an OpenAI-compatible endpoint (\texttt{api.asi1.ai}):
-\texttt{asi1}, \texttt{asi1-fast}, \texttt{asi1-extended},
-\texttt{asi1-graph}, \texttt{asi1-agentic}, \texttt{asi1-fast-agentic},
-and \texttt{asi1-extended-agentic}.  The \textsc{api} additionally supports real-time web
-search, structured output with \textsc{json} schema, image generation, and
-streaming.
+\item \textbf{ASI:One}: A unified \textsc{llm} \textsc{api} available via an
+OpenAI-compatible endpoint (\texttt{api.asi1.ai/v1}).  The primary model,
+\texttt{asi1}, is a unified model that automatically adapts its capabilities
+based on the request---activating agentic reasoning, extended analysis, fast
+inference, tool calling, or knowledge-graph traversal as needed.  A
+lightweight variant, \texttt{asi1-mini}, is available for resource-constrained
+applications.  The \textsc{api} additionally supports real-time web search,
+structured output with \textsc{json} schema, image generation, and streaming.
 
 \item \textbf{Payment Protocol}: A built-in buyer-seller protocol supporting
 Stripe (fiat), Skyfire \textsc{usdc}, and \textsc{fet}/\textsc{asi} on-chain
@@ -502,12 +511,14 @@ Desktop and FetchCoder.
 \label{subsec:audit}
 
 Our gap analysis is grounded in a systematic empirical audit of the Agentverse
-\textsc{api} surface.  The platform exposes approximately \textbf{204
-documented endpoints} across two \textsc{api} versions (\texttt{v1} and
-\texttt{v2}) at \url{https://agentverse.ai}.  We tested each endpoint category
-with authenticated requests using a production \textsc{api} key (scope:
-\texttt{av}), supplemented by analysis of the Fern-generated documentation,
-\textsc{sdk} source code, and community resources.
+\textsc{api} surface.  At the time of our audit (Q1~2026), the platform
+documented approximately \textbf{204 endpoints} across two \textsc{api}
+versions (\texttt{v1} and \texttt{v2}) at \url{https://agentverse.ai};
+the \textsc{api} surface is actively evolving, and endpoint availability may
+differ from this count at the time of reading.  We tested each endpoint
+category with authenticated requests using a production \textsc{api} key
+(scope: \texttt{av}), supplemented by analysis of the Fern-generated
+documentation, \textsc{sdk} source code, and community resources.
 
 Key findings from the audit:
 
@@ -520,8 +531,11 @@ token.
 beyond the basic bearer token (notably, mailbox endpoints require agent-level
 attestation via challenge-response).
 
-\item \textbf{V2 Almanac and most V2 Hosting endpoints return 404}---they are
-documented but not yet deployed to production.
+\item \textbf{V2 Almanac resolve is operational} (returning full agent records);
+other V2 Almanac endpoints return 404.  Several V2 Hosting list endpoints
+(\texttt{/agents}, \texttt{/secrets}, \texttt{/storage}) are deployed but
+require authentication (401); most V2 Hosting per-agent endpoints return
+404---documented but not yet available in production.
 
 \item \textbf{The practical working \textsc{api} mixes V2 for agent
 \textsc{crud}} (create, read, update, delete) \textbf{and V1 for hosting,
@@ -549,7 +563,11 @@ Section~\ref{sec:gaps}.  The discrepancy between documented and deployed
 endpoints is itself instructive: it suggests that the platform team has
 articulated a broader vision than the current production system realises,
 consistent with our characterisation of Agentverse as an early-stage agent
-cloud undergoing rapid expansion.
+cloud undergoing rapid expansion.  We note that the \textsc{api} surface is
+actively evolving; some endpoints documented at the time of our audit have
+since been modified, consolidated, or deprecated, and new ones may have
+been added.  All quantitative endpoint claims in this paper should be read
+with this dynamism in mind.
 
 \subsection{What Currently Works Well}
 \label{subsec:strengths}
@@ -574,10 +592,11 @@ the Almanac without approval, enabling a genuinely open ecosystem.  The over
 36,000 agents discoverable in the Almanac as of Q1 2026 reflects the traction
 this openness creates.
 
-\textbf{Multi-model \textsc{llm} access.} ASI:One provides access to seven
-specialised models via a single \textsc{api}, including an agentic model family
-designed for tool use and multi-step reasoning, and a graph model for
-structured knowledge tasks.
+\textbf{Unified \textsc{llm} access.} ASI:One provides a single \textsc{api}
+(\texttt{asi1}) that automatically adapts its capabilities to the request,
+encompassing agentic reasoning, tool use, extended analysis, and structured
+knowledge tasks.  A lightweight \texttt{asi1-mini} variant complements it for
+resource-constrained applications.
 
 \textbf{Native payment protocol.} The integration of payment as a first-class
 protocol (rather than a bolt-on billing system) reflects a principled design
@@ -589,9 +608,9 @@ Agentverse is built on an open blockchain, meaning that the Almanac, agent
 identities, and on-chain transactions are not owned by any single corporation
 and cannot be unilaterally revoked.
 
-These strengths position Agentverse as the correct foundation on which to build
-the agent cloud of 2030.  The gap analysis that follows should be read not as
-a critique but as a roadmap.
+These strengths position Agentverse as the strongest decentralised foundation
+currently available for building the agent cloud of 2030.  The gap analysis
+that follows should be read not as a critique but as a roadmap.
 
 % =============================================================================
 \section{Gap Analysis: What the Agent Cloud Is Missing}
@@ -985,10 +1004,14 @@ designed to close the gaps while preserving these advantages.
 
 Drawing on the gap analysis of Section~\ref{sec:gaps} and the cloud computing
 reference model of Section~\ref{subsec:cloud-reference}, we propose a
-seven-layer reference architecture for a fully realised agent cloud platform.
-Each layer addresses one or more gap categories from Section~\ref{sec:gaps}.
-The layers are ordered from infrastructure (Layer~0) to application (Layer~6),
-following the convention of the \textsc{osi} model.
+seven-layer reference architecture for a fully realised \textsc{aaas} (Agents
+as a Service) cloud platform.  This stack is the \textsc{aaas} equivalent of
+the \textsc{osi} model: a principled decomposition of every capability an
+agent cloud must provide, from cryptographic identity at the substrate to
+economic exchange at the application layer.  Each layer addresses one or more
+gap categories from Section~\ref{sec:gaps}.  The layers are ordered from
+infrastructure (Layer~0) to application (Layer~6), following the convention
+of the \textsc{osi} model.
 
 \begin{figure}[htbp]
 \centering
@@ -1405,7 +1428,8 @@ agent markets with heterogeneous participants is an open problem.
 \subsection{Regulatory Considerations}
 \label{subsec:regulatory}
 
-The EU AI Act (high-risk provisions in force from August 2, 2026) classifies
+The EU AI Act (Regulation (EU)~2024/1689; high-risk provisions in force from
+August~2, 2026) classifies
 \textsc{ai} systems by risk level.  Autonomous agents taking consequential
 actions---financial transactions, medical decisions, legal submissions---are
 likely to be classified as high-risk, triggering requirements for human
@@ -1435,8 +1459,8 @@ mechanism design treatment of each would require dedicated theoretical work.
 % =============================================================================
 
 We have presented a systematic analysis of the Agentverse platform as a case
-study in agent-native cloud infrastructure.  Our empirical audit of 204
-\textsc{api} endpoints reveals 52 capability gaps across eight
+study in agent-native cloud infrastructure.  Our empirical audit of 204 \textsc{api} endpoints (as documented in Q1~2026)
+reveals 52 capability gaps across eight
 categories---from agent memory and observability to security, communication,
 data services, economic primitives, and enterprise-grade scaling.  These gaps
 are not failures of vision but the natural condition of pioneering
@@ -1466,7 +1490,10 @@ communicate across platforms, verify each other's identity, and transact
 economically---will shape outcomes in commerce, science, and governance far
 beyond the scope of any individual agent application.  Agentverse, uniquely
 among current platforms, is architecturally positioned to provide that
-infrastructure in an open, decentralised, and composable form.  The distance
+infrastructure in an open, decentralised, and composable form.  The seven-layer
+stack we propose constitutes the full \textsc{aaas} (Agents as a Service)
+model: the principled service abstraction for the agentic era, as foundational
+to the agent cloud as \textsc{iaas} was to the compute cloud.  The distance
 between where it is today and where it needs to be by 2030 is large but
 well-defined.  This paper is a map of that distance.
 


### PR DESCRIPTION
## Summary

This PR resolves all open issues from the FETCH-AGI paper review and independent API audit (two commit batches).

### 🔴 Critical
- **#1** — Fixed `seven seven` repeated word typo
- **#2** — Added `Table~\ref{}` cross-references for all 8 gap tables and `Figure~\ref{fig:stack}` in architecture section
- **#4** — Added missing citations: `uagents2026sdk`, `agentverse2026docs`, `yang2026graphsurvey`
- **#6** — Fixed gap count from 52 → 62 (verified by counting all table rows: A7+B8+C8+D8+E8+F7+G8+H8=62)
- **#17** — Fixed ASI:One model description: removed `seven seven` typo, replaced outdated 7-model list with accurate unified `asi1` + `asi1-mini` description per current docs

### 🟡 Medium
- **#3** — Fixed 30-page forward reference to `tab:platform-comparison`: changed to parenthetical `(Section~\ref{sec:discussion}, Table~\ref{tab:platform-comparison})`
- **#5** — Added fourth limitation acknowledging the categorical (not quantitative) nature of the audit; directed future work to performance benchmarks
- **#7** — Added footnote on ElizaOS/Virtuals explaining why they are not analysed in depth (no comparable REST API surface)
- **#18** — Added `Q1 2026` timestamp caveats in all four places where the 204-endpoint count appears
- **#19** — Corrected V2 endpoint status: V2 Almanac resolve = 200 ✅; V2 Hosting lists = 401; V2 per-agent = 404 — paper previously conflated 401 and 404
- **#20** — Added footnote on first 36K agent mention explaining the search API 10K cap and Kantor source methodology
- **#21** — Added evolving-API caveat sentence in audit methodology section

### 🔵 Minor / Stylistic
- **#8** — Converted 2 passive constructions in Background section to active voice
- **#9** — AaaS acronym now used 5× across paper (was 2×)
- **#10** — Web4 terminology hedged away from single-source assertion
- **#11** — Softened `the correct foundation` → `the strongest decentralised foundation currently available`
- **#13** — Added EU AI Act regulation number `(Regulation (EU) 2024/1689)`
- **#14** — Removed `4/26` submission date from `\jmlrheading`
- **#15** — AWS 2006 analogy reframed as opportunity rather than deficiency
- **#16** — Small caps `\textsc{}` confirmed intentional; no change

Closes #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #13, #14, #15, #16, #17, #18, #19, #20, #21